### PR TITLE
Fix CI pipeline (pylint)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,13 +4,13 @@ name: default
 
 steps:
 - name: lint
-  image: python:3.6
+  image: python:3.8
   commands:
   - &setup pip install -r requirements.txt
   - pylint --fail-under=9.0 -d pep8 matrix_synapse_saml_mapper/*.py setup.py
 
 - name: build
-  image: python:3.6
+  image: python:3.8
   commands:
   - *setup
   - python setup.py sdist bdist_wheel
@@ -18,7 +18,7 @@ steps:
   - lint
 
 - name: test
-  image: python:3.6
+  image: python:3.8
   commands:
   - *setup
   - python setup.py install

--- a/.drone.yml
+++ b/.drone.yml
@@ -7,7 +7,7 @@ steps:
   image: python:3.6
   commands:
   - &setup pip install -r requirements.txt
-  - pylint-fail-under --fail_under 9.0 -d pep8 matrix_synapse_saml_mapper/*.py setup.py
+  - pylint --fail-under=9.0 -d pep8 matrix_synapse_saml_mapper/*.py setup.py
 
 - name: build
   image: python:3.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 pylint>=2.6.0
-pylint-fail-under>=0.3.0
 attr>=0.3.1
 attrs>=19.3.0
 psycopg2>=2.8.6


### PR DESCRIPTION
Switches from `pylint-fail-under` to `pylint --fail-under=...` to fix the CI pipeline